### PR TITLE
added .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most editorconfig file
+root = true
+
+# defaults
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+max_line_length = 120


### PR DESCRIPTION
- this aligns with the settings within the markdownlint.yaml file. note,
  that not all editors support the max_line_length property.