### PR TITLE
Adding site_url and analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Open Management
+site_url: https://aristanetworks.github.io/openmgmt/
 theme: mkdocs
 theme:
   name: material
@@ -6,3 +7,7 @@ theme:
     scheme: slate
     primary: blue
     accent: orange
+extra:
+  analytics:
+    provider: google
+    property: G-4V8W728SS9


### PR DESCRIPTION
New version of mkdocs requires `site_url` field and adding google analytics