### PR TITLE
examples: add more cli origin examples

### DIFF
--- a/docs/examples/gnmi-clients/arista-gnmi/index.md
+++ b/docs/examples/gnmi-clients/arista-gnmi/index.md
@@ -901,7 +901,10 @@ gnmi -addr 10.83.28.203:6030 -username arista -password arista \
 
 ```shell
 gnmi -addr 10.83.28.203:6030 -username admin -password arista \
-  update /acl/acl-sets acl2.json`
+  update /acl/acl-sets acl2.json
+```
+
+```shell
 cat acl2.json
 ```
 
@@ -996,3 +999,50 @@ gnmi -addr 10.83.13.214:6030 -username admin -password arista \
   subscribe                                                   \
   '/network-instances/network-instance[name=Tenant_A_WEB_Zone]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=10.255.251.1]/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/state/prefixes/received'
 ```
+
+## CLI origin
+
+### Changing the maximum-routes for a BGP neighbor
+
+```shell
+gnmi -addr 10.83.13.214:6030 -username arista -password arista \
+    update origin=cli "" "router bgp 65101
+    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12500"
+```
+
+> Note the `neighbor` command has to be on a new line, so the previous line should not and in `\`.
+
+### show version
+
+```shell
+gnmi -addr 10.83.13.214:6030 -username cvpadmin -password arastra \
+   get  origin=cli "show version"
+```
+
+<details><summary> Reveal output</summary>
+<p>
+
+```javascript
+/show version:
+{
+  "architecture": "i686",
+  "bootupTimestamp": 1626291561.0,
+  "configMacAddress": "00:00:00:00:00:00",
+  "hardwareRevision": "",
+  "hwMacAddress": "00:00:00:00:00:00",
+  "imageFormatVersion": "1.0",
+  "internalBuildId": "ed275a6c-1771-482d-829b-125e9c6ba677",
+  "internalVersion": "4.26.2F-23035564.riorel",
+  "isIntlVersion": false,
+  "memFree": 2422124,
+  "memTotal": 4002356,
+  "mfgName": "Arista",
+  "modelName": "vEOS-lab",
+  "serialNumber": "BAD032986065E8DC14CBB6472EC314A6",
+  "systemMacAddress": "50:08:00:a7:ca:c3",
+  "uptime": 1814877.63,
+  "version": "4.26.2F-23035564.riorel (engineering build)"
+}
+
+</p>
+</details>

--- a/docs/examples/gnmi-clients/arista-gnmi/index.md
+++ b/docs/examples/gnmi-clients/arista-gnmi/index.md
@@ -1010,7 +1010,7 @@ gnmi -addr 10.83.13.214:6030 -username arista -password arista \
     neighbor IPv4-UNDERLAY-PEERS maximum-routes 12500"
 ```
 
-> Note the `neighbor` command has to be on a new line, so the previous line should not and in `\`.
+> NOTE the `neighbor` command has to be on a new line, so the previous line should not and in `\`.
 
 ### show version
 

--- a/docs/examples/gnmi-clients/arista-gnmi/index.md
+++ b/docs/examples/gnmi-clients/arista-gnmi/index.md
@@ -1010,7 +1010,7 @@ gnmi -addr 10.83.13.214:6030 -username arista -password arista \
     neighbor IPv4-UNDERLAY-PEERS maximum-routes 12500"
 ```
 
-> NOTE the `neighbor` command has to be on a new line, so the previous line should not and in `\`.
+> NOTE the `neighbor` command has to be on a new line, so the previous line should not end in `\`.
 
 ### show version
 

--- a/docs/examples/gnmi-clients/gnmic/index.md
+++ b/docs/examples/gnmi-clients/gnmic/index.md
@@ -1082,6 +1082,168 @@ gnmic -a 127.0.0.1:6030 -u admin -p admin --insecure  get \
   | jq '.[0].updates[0].values."show ip route summary".totalRoutes'
 ```
 
+### Changing the running-config
+
+There are multiple ways to change the configuration using the `cli` origin:
+
+#### Using JSON
+
+Multiple config sections can be change at a time, for instance in the below example vlan 304 is created and
+the description of Ethernet1 is changed:
+
+```shell
+ gnmic -a 10.83.13.214:6030 -u admin -p admin --insecure --gzip set \
+    --request-file intf.json
+```
+
+Output:
+
+<details><summary> Reveal output</summary>
+<p>
+
+```javascript
+{
+  "timestamp": 1628103804792021864,
+  "time": "2021-08-04T20:03:24.792021864+01:00",
+  "results": [
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    }
+  ]
+}
+```
+
+</p>
+</details>
+
+```shell
+cat intf.json
+```
+
+```javascript
+{
+  "updates": [
+    {
+      "path": "cli:",
+      "value": "interface Ethernet 1",
+      "encoding": "ascii"
+    },
+    {
+      "path": "cli:",
+      "value": "description arista-openmgmt",
+      "encoding": "ascii"
+    },
+    {
+      "path": "cli:",
+      "value": "vlan 304",
+      "encoding": "ascii"
+    },
+    {
+      "path": "cli:",
+      "value": "name test",
+      "encoding": "ascii"
+    }
+  ]
+}
+```
+
+#### Using yaml
+
+Changing the maximum-routes for a BGP neighbor:
+
+```shell
+gnmic -a 10.83.13.214:6030 -u cvpadmin -p arista --insecure --gzip set \
+   --request-file bgp.yaml
+```
+
+Output:
+
+<details><summary> Reveal output</summary>
+<p>
+
+```javscript
+{
+  "timestamp": 1628091791855672771,
+  "time": "2021-08-04T16:43:11.855672771+01:00",
+  "results": [
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    }
+  ]
+}
+```
+
+</p>
+</details>
+
+```shell
+cat bgp.yaml
+```
+
+```yaml
+updates:
+ - path: "cli:"
+   value: router bgp 65101
+   encoding: ascii
+ - path: "cli:"
+   value: neighbor IPv4-UNDERLAY-PEERS maximum-routes 15500
+   encoding: ascii
+```
+
+#### Using imperative commands
+
+```shell
+gnmic -a 10.83.13.214:6030 -u cvpadmin -p arista --insecure --gzip \
+   --encoding ASCII set \
+   --update-path "cli:" \
+   --update-value "router bgp 65101" \
+   --update-path "cli:" \
+   --update-value "neighbor IPv4-UNDERLAY-PEERS maximum-routes 13500"
+```
+
+Output:
+
+<details><summary> Reveal output</summary>
+<p>
+
+```javascript
+{
+  "timestamp": 1628091405938523430,
+  "time": "2021-08-04T16:36:45.93852343+01:00",
+  "results": [
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "cli:"
+    }
+  ]
+}
+```
+
+</p>
+</details>
+
 ## Misc
 
 ### Save all status states to a file

--- a/docs/examples/gnmi-clients/gnmic/index.md
+++ b/docs/examples/gnmi-clients/gnmic/index.md
@@ -1160,7 +1160,7 @@ cat intf.json
 }
 ```
 
-#### Using yaml
+#### Using YAML
 
 Changing the maximum-routes for a BGP neighbor:
 


### PR DESCRIPTION
Added a few more `origin=cli` examples using both `gnmi`(Arista) and `gnmic` clients