### PR TITLE
Adding automatic marking of stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '39 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,10 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 180
+        days-before-issue-close: 14
         stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
+        days-before-pr-close: 14
+        stale-pr-message: 'Stale pull request message'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Addressing Issue #80 this will only mark and close stale  issues/PRs, not necessarily branches. We can add this:
https://github.com/actions/stale#delete-branch
if we want to delete associated branches too, but maybe run this version first, then add the branch deletion later if desired.