### PR TITLE
misc. lintpickens

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -26,6 +26,7 @@ MD007:
 MD013:
   line_length: 120
   code_block_line_length: 450
+  tables: false
 
 # multiple headings with the same content
 # siblings_only is set here to allow for common header values in structured
@@ -43,7 +44,7 @@ MD032:
 
 # MD033/no-inline-html - Inline HTML
 MD033:
- allowed_elements: [ "details", "p", "summary" ]
+ allowed_elements: [ "br", "code", "details", "p", "pre", "span", "summary" ]
 
 # bare URL - bare URLs shoudl be wrapped in angle brackets
 # <https://eos.arista.com>

--- a/docs/examples/netconf/ncclient.md
+++ b/docs/examples/netconf/ncclient.md
@@ -140,30 +140,44 @@ python3 print_server_capabilities.py
 
 #### Capabilities
 
-- [print_client_capabilities.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/print_client_capabilities.py) prints the NETCONF client capabilities.
-- [print_server_capabilities.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/print_server_capabilities.py) prints the NETCONF server capabilities.
+- [print_client_capabilities.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/print_client_capabilities.py)
+  prints the NETCONF client capabilities.
+- [print_server_capabilities.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/print_server_capabilities.py)
+  prints the NETCONF server capabilities.
 
 #### get operation
 
-- [get.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/get.py) uses the `get` operation to retrieve the configuration and state data. It uses a filter to specify the portion of the configuration and state data to retrieve.
+- [get.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/get.py) uses the `get` operation to
+  retrieve the configuration and state data. It uses a filter to specify the portion of the configuration and state data
+  to retrieve.
 
 #### get-config operation
 
-- [get_config.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/get_config.py) uses the `get-config` operation with a filter to retrieve part of the configuration.
+- [get_config.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/get_config.py) uses the `get-config`
+  operation with a filter to retrieve part of the configuration.
 
 #### edit-config operation
 
-- [edit_config_merge.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_merge.py) uses the `edit-config` operation with the `merge` operation (which is the default operation for `edit-config`)
-- [edit_config_replace.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_replace.py) uses the `edit-config` operation with the `replace` operation
-- [edit_config_delete.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_delete.py)
-uses the `edit-config` operation with the `delete` operation
-- [EOS_commands_with_NETCONF.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/EOS_commands_with_NETCONF.py) configures a device using the `edit-config` operation and EOS data model
-- [candidate_configuration_commit.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/candidate_configuration_commit.py) uses the `edit-config` operation with the `candidate` configuration datastore. It uses a `lock` operation and `commit` operation.
-- [candidate_configuration_discard_changes.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/candidate_configuration_discard_changes.py). uses the `edit-config` operation with the `candidate` configuration datastore. It uses a `lock` operation and `discard_change` operation to revert the candidate configuration to the current running configuration (insteaf of commiting the candidate configuration).
-#### XML output parsing
+- [edit_config_merge.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_merge.py) uses
+  the `edit-config` operation with the `merge` operation (which is the default operation for `edit-config`)
+- [edit_config_replace.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_replace.py)
+  uses the `edit-config` operation with the `replace` operation
+- [edit_config_delete.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/edit_config_delete.py) uses
+  the `edit-config` operation with the `delete` operation
+- [EOS_commands_with_NETCONF.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/EOS_commands_with_NETCONF.py)
+  configures a device using the `edit-config` operation and EOS data model
+- [candidate_configuration_commit.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/candidate_configuration_commit.py)
+  uses the `edit-config` operation with the `candidate` configuration datastore. It uses a `lock` operation and `commit`
+  operation.
+- [candidate_configuration_discard_changes.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/candidate_configuration_discard_changes.py).
+  uses the `edit-config` operation with the `candidate` configuration datastore. It uses a `lock` operation and
+  `discard_change` operation to revert the candidate configuration to the current running configuration (insteaf of
+  commiting the candidate configuration).  #### XML output parsing
 
-- [parse_xml_output.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/parse_xml_output.py) uses the `get` operation to retrieve data from the device and then parse this data.
+- [parse_xml_output.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/parse_xml_output.py) uses the
+  `get` operation to retrieve data from the device and then parse this data.
 
 #### RPC
 
-- [rpc.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/rpc.py) sends RPCs to configure EOS devices.
+- [rpc.py](https://github.com/aristanetworks/openmgmt/tree/main/src/ncclient/rpc.py) sends RPCs to configure EOS
+  devices.

--- a/docs/examples/netconf/netconf_over_ssh.md
+++ b/docs/examples/netconf/netconf_over_ssh.md
@@ -6,6 +6,7 @@ management api netconf
    transport ssh test
       vrf MGMT
 ```
+
 ```shell
 switch1#sh management api netconf
 Enabled:            Yes
@@ -23,7 +24,6 @@ In order to open a NETCONF session inside an SSH connection, there are two optio
 - we can establish an SSH connection to an EOS device (NETCONF server), and then run the EOS command
       - `netconf start-client`
 
-
 ## NETCONF over SSH demo
 
 ### Start a NETCONF over SSH session
@@ -38,7 +38,7 @@ Once the NETCONF session is open, the NETCONF server (EOS device) advertises its
 
 You must advertise the client capabilities. Example:
 
-```shell
+```xml
 <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
     <capabilities>
         <capability>urn:ietf:params:netconf:base:1.0</capability>
@@ -53,7 +53,7 @@ You must advertise the client capabilities. Example:
 
 ### Get all configuration and state data
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1">
   <get>
   </get>
@@ -63,7 +63,7 @@ You must advertise the client capabilities. Example:
 
 ### Get the operational status of an Interface
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="2">
   <get>
     <filter type="subtree">
@@ -84,7 +84,7 @@ You must advertise the client capabilities. Example:
 
 ### Get the whole running configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="3">
   <get-config>
     <source>
@@ -97,7 +97,7 @@ You must advertise the client capabilities. Example:
 
 ### Get the running configuration of an interface
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="4">
   <get-config>
     <source>
@@ -117,7 +117,7 @@ You must advertise the client capabilities. Example:
 
 ### Get the interface description from the running configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="5">
   <get-config>
     <source>
@@ -141,7 +141,7 @@ You must advertise the client capabilities. Example:
 
 ### Lock the running configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="6">
   <lock>
     <target>
@@ -154,7 +154,7 @@ You must advertise the client capabilities. Example:
 
 ### Edit the running configuration using EOS native data model
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="7">
 <edit-config>
     <target>
@@ -175,7 +175,7 @@ You must advertise the client capabilities. Example:
 
 ### Edit the running configuration using OpenConfig data model
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="8">
 <edit-config>
     <target>
@@ -199,7 +199,7 @@ You must advertise the client capabilities. Example:
 
 ### Edit the running configuration to delete an existing existing data
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="9">
 <edit-config>
     <target>
@@ -224,7 +224,7 @@ You must advertise the client capabilities. Example:
 
 ### Unlock the running configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="10">
   <unlock>
     <target>
@@ -237,7 +237,7 @@ You must advertise the client capabilities. Example:
 
 ### Save running configuration on the flash
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="11">
   <copy-config>
     <target>
@@ -255,7 +255,7 @@ You must advertise the client capabilities. Example:
 
 ### Copy the running configuration datastore to the startup configuration datastore
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="12">
     <copy-config>
         <target>
@@ -271,7 +271,7 @@ You must advertise the client capabilities. Example:
 
 ### Lock the candidate configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="13">
   <lock>
     <target>
@@ -282,9 +282,9 @@ You must advertise the client capabilities. Example:
 ]]>]]>
 ```
 
-### Edit the candidate configuration
+### Edit the candidate configuration - edit interface description
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="14">
 <edit-config>
     <target>
@@ -308,7 +308,7 @@ You must advertise the client capabilities. Example:
 
 ### Commit the configuration change (from the candidate to the running configuration)
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="15">
     <commit/>
 </rpc>
@@ -317,7 +317,7 @@ You must advertise the client capabilities. Example:
 
 ### Unlock the candidate configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="20">
   <unlock>
     <target>
@@ -328,9 +328,9 @@ You must advertise the client capabilities. Example:
 ]]>]]>
 ```
 
-### Edit the candidate configuration
+### Edit the candidate configuration - set hostname
 
-```
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="21">
 <edit-config>
     <target>
@@ -351,7 +351,7 @@ You must advertise the client capabilities. Example:
 
 ### Get part of the candidate configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="5">
   <get-config>
     <source>
@@ -371,9 +371,10 @@ You must advertise the client capabilities. Example:
 
 ### Revert the candidate configuration to the current running configuration
 
-If you decide to not commit the candidate configuration, you can revert the candidate configuration to the current running configuration
+If you decide to not commit the candidate configuration, you can revert the candidate configuration to the current
+running configuration
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="90">
   <discard-changes/>
 </rpc>
@@ -382,7 +383,7 @@ If you decide to not commit the candidate configuration, you can revert the cand
 
 ### Close the session
 
-```shell
+```xml
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="100">
     <close-session>
     </close-session>

--- a/docs/examples/pyangbind/index.md
+++ b/docs/examples/pyangbind/index.md
@@ -25,7 +25,7 @@ pip3 freeze | grep pyang
 
 ## Get YANG modules
 
-We need YANG modules so we can use Pyang and Pyangbind. 
+We need YANG modules so we can use Pyang and Pyangbind.
 
 ### Create a directory
 
@@ -80,7 +80,8 @@ ls oc_bgp.py
 
 ## Use the new python module to generate an OpenConfig configuration file
 
-The file [pyangbind_demo.py](https://github.com/aristanetworks/openmgmt/tree/main/src/pyangbind/pyangbind_demo.py) uses the new python module `oc_bgp.py` and generates this OpenConfig configuration file [demo.json](demo.json)
+The file [pyangbind_demo.py](https://github.com/aristanetworks/openmgmt/tree/main/src/pyangbind/pyangbind_demo.py) uses
+the new python module `oc_bgp.py` and generates this OpenConfig configuration file [demo.json](demo.json)
 
 ```shell
 python3 pyangbind_demo.py
@@ -89,14 +90,17 @@ python3 pyangbind_demo.py
 ## Use gNMI SET RPC to configure a device
 
 This OpenConfig configuration file [demo.json](demo.json) can be loaded on a switch using the gNMI Set RPC
+
 ### Install gNMIc
 
 Please visit [this link](../gnmi-clients/gnmic/index.md) if you need help with gNMIc installation
+
 ### Required device configuration
 
 Please visit [this link](../gnmi-clients/gnmic/index.md) if you need help to configure EOS for gNMI
 
 ### Use gNMIc to configure the swicth
+
 #### Check the device configuration before
 
 ```shell
@@ -112,7 +116,8 @@ show run section bgp
 
 ```shell
 gnmic -a 10.73.1.117:6030 --insecure -u arista -p arista set  \
-    --replace-path '/network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/bgp' --replace-file demo.json
+    --replace-path '/network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/bgp' \
+    --replace-file demo.json
 ```
 
 #### Check the device configuration after

--- a/docs/examples/pygnmi/index.md
+++ b/docs/examples/pygnmi/index.md
@@ -31,7 +31,9 @@ Assuming that the `pygnmi` module has been installed, this can be executed via t
 python3 gnmi_example.py
 ```
 
-The following will simply run the [`gnmi_example.py`](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/gnmi_example.py) file using python3 to get the openconfig interfaces.
+The following will simply run the
+[`gnmi_example.py`](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/gnmi_example.py) file using python3
+to get the openconfig interfaces.
 
 Truncated output
 
@@ -60,7 +62,8 @@ Truncated output
 
 ## gNMI Capabilities RPC
 
-The file [capabilities.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/capabilities.py) uses the [pygnmi](https://pypi.org/project/pygnmi/) python module to get the gNMI capabilities.
+The file [capabilities.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/capabilities.py) uses the
+[pygnmi](https://pypi.org/project/pygnmi/) python module to get the gNMI capabilities.
 
 ```shell
 python3 capabilities.py
@@ -69,7 +72,7 @@ python3 capabilities.py
 <details><summary>Reveal output</summary>
 <p>
 
-```shell
+```json
 {'gnmi_version': '0.7.0',
  'supported_encodings': ['json', 'json_ietf', 'ascii'],
  'supported_models': [{'name': 'arista-exp-eos-varp-net-inst',
@@ -507,7 +510,8 @@ python3 capabilities.py
 
 ## gNMI Get RPC
 
-The file [get.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/get.py) uses the [pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI GET RPC
+The file [get.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/get.py) uses the
+[pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI GET RPC
 
 ```shell
 python3 get.py
@@ -596,7 +600,8 @@ python3 get.py
 
 ## gNMI Subscribe RPC
 
-The file [sub.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/sub.py) uses the [pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI Subscribe RPC
+The file [sub.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/sub.py) uses the
+[pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI Subscribe RPC
 
 ```shell
 python3 sub.py
@@ -605,7 +610,7 @@ python3 sub.py
 <details><summary>Reveal output</summary>
 <p>
 
-```shell
+```json
 {'update': {'update': [{'path': 'interfaces/interface[name=Ethernet1]/state/counters/in-broadcast-pkts', 'val': 2}], 'timestamp': 1626462768674581749}}
 {'update': {'update': [{'path': 'interfaces/interface[name=Ethernet1]/state/counters/in-discards', 'val': 0}], 'timestamp': 1626462768674597259}}
 {'update': {'update': [{'path': 'interfaces/interface[name=Ethernet1]/state/counters/in-errors', 'val': 0}], 'timestamp': 1626462768674603747}}
@@ -712,16 +717,18 @@ python3 sub.py
 
 ### Update
 
-The file [update.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/update.py) uses the [pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI SET RPC (update)
+The file [update.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/update.py) uses the
+[pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI SET RPC (update)
 
 ```shell
 python3 update.py
 ```
 
-output
+### output
 
-```shell
 GET RPC, interface Ethernet1 config, before the update
+
+```json
 {
   "notification": [
     {
@@ -744,8 +751,11 @@ GET RPC, interface Ethernet1 config, before the update
     }
   ]
 }
+```
 
 SET RPC, update, interface Ethernet1
+
+```json
 {'response': [{'path': 'interfaces/interface[name=Ethernet1]', 'op': 'UPDATE'}]}
 
 GET RPC, interface Ethernet1 config, after the update
@@ -778,7 +788,8 @@ GET RPC, interface Ethernet1 config, after the update
 
 ### Delete
 
-The file [delete.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/delete.py) uses the [pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI SET RPC (delete)
+The file [delete.py](https://github.com/aristanetworks/openmgmt/blob/main/src/pygnmi/delete.py) uses the
+[pygnmi](https://pypi.org/project/pygnmi/) python module and uses the gNMI SET RPC (delete)
 
 ```shell
 python3 delete.py

--- a/docs/examples/restconf/python.md
+++ b/docs/examples/restconf/python.md
@@ -45,7 +45,15 @@ True
 >>> result.content
 b'{"openconfig-interfaces:admin-status":"UP","openconfig-interfaces:counters":{"in-broadcast-pkts":"0","in-discards":"0","in-errors":"0","in-fcs-errors":"0","in-multicast-pkts":"972","in-octets":"116602","in-unicast-pkts":"131","out-broadcast-pkts":"1","out-discards":"0","out-errors":"0","out-multicast-pkts":"1761","out-octets":"199997","out-unicast-pkts":"122"},"openconfig-interfaces:description":"restconf_test","openconfig-interfaces:enabled":true,"openconfig-platform-port:hardware-port":"Port1","openconfig-interfaces:ifindex":1,"arista-intf-augments:inactive":false,"openconfig-interfaces:last-change":"1624966430515012864","openconfig-interfaces:loopback-mode":false,"openconfig-interfaces:mtu":0,"openconfig-interfaces:name":"Ethernet1","openconfig-interfaces:oper-status":"UP","openconfig-vlan:tpid":"openconfig-vlan-types:TPID_0X8100","openconfig-interfaces:type":"iana-if-type:ethernetCsmacd"}\n'
 >>> result.json()
-{'openconfig-interfaces:admin-status': 'UP', 'openconfig-interfaces:counters': {'in-broadcast-pkts': '0', 'in-discards': '0', 'in-errors': '0', 'in-fcs-errors': '0', 'in-multicast-pkts': '972', 'in-octets': '116602', 'in-unicast-pkts': '131', 'out-broadcast-pkts': '1', 'out-discards': '0', 'out-errors': '0', 'out-multicast-pkts': '1761', 'out-octets': '199997', 'out-unicast-pkts': '122'}, 'openconfig-interfaces:description': 'restconf_test', 'openconfig-interfaces:enabled': True, 'openconfig-platform-port:hardware-port': 'Port1', 'openconfig-interfaces:ifindex': 1, 'arista-intf-augments:inactive': False, 'openconfig-interfaces:last-change': '1624966430515012864', 'openconfig-interfaces:loopback-mode': False, 'openconfig-interfaces:mtu': 0, 'openconfig-interfaces:name': 'Ethernet1', 'openconfig-interfaces:oper-status': 'UP', 'openconfig-vlan:tpid': 'openconfig-vlan-types:TPID_0X8100', 'openconfig-interfaces:type': 'iana-if-type:ethernetCsmacd'}
+{'openconfig-interfaces:admin-status': 'UP', 'openconfig-interfaces:counters': {'in-broadcast-pkts': '0', 'in-discards':
+'0', 'in-errors': '0', 'in-fcs-errors': '0', 'in-multicast-pkts': '972', 'in-octets': '116602', 'in-unicast-pkts':
+'131', 'out-broadcast-pkts': '1', 'out-discards': '0', 'out-errors': '0', 'out-multicast-pkts': '1761', 'out-octets':
+'199997', 'out-unicast-pkts': '122'}, 'openconfig-interfaces:description': 'restconf_test',
+'openconfig-interfaces:enabled': True, 'openconfig-platform-port:hardware-port': 'Port1',
+'openconfig-interfaces:ifindex': 1, 'arista-intf-augments:inactive': False, 'openconfig-interfaces:last-change':
+'1624966430515012864', 'openconfig-interfaces:loopback-mode': False, 'openconfig-interfaces:mtu': 0,
+'openconfig-interfaces:name': 'Ethernet1', 'openconfig-interfaces:oper-status': 'UP', 'openconfig-vlan:tpid':
+'openconfig-vlan-types:TPID_0X8100', 'openconfig-interfaces:type': 'iana-if-type:ethernetCsmacd'}
 >>> result.json()['openconfig-interfaces:oper-status']
 'UP'
 >>> result.json()['openconfig-interfaces:counters']['out-octets']
@@ -115,12 +123,22 @@ Execute the python script [delete_lo100.py](https://github.com/aristanetworks/op
 python3 delete_lo100.py
 ```
 
-output
+output (note the following has been formatted for readability.)
 
 ```shell
 get int lo100
 status_code is 200
-content is {'openconfig-interfaces:config': {'description': '222', 'enabled': True, 'arista-intf-augments:load-interval': 300, 'loopback-mode': True, 'name': 'Loopback100', 'openconfig-vlan:tpid': 'openconfig-vlan-types:TPID_0X8100', 'type': 'iana-if-type:softwareLoopback'}, 'openconfig-interfaces:hold-time': {'config': {'down': 0, 'up': 0}, 'state': {'down': 0, 'up': 0}}, 'openconfig-interfaces:name': 'Loopback100', 'openconfig-interfaces:state': {'enabled': True, 'loopback-mode': False, 'openconfig-vlan:tpid': 'openconfig-vlan-types:TPID_0X8100'}, 'openconfig-interfaces:subinterfaces': {'subinterface': [{'config': {'description': '222', 'enabled': True, 'index': 0}, 'index': 0, 'openconfig-if-ip:ipv4': {'config': {'dhcp-client': False, 'enabled': True, 'mtu': 1500}, 'state': {'dhcp-client': False, 'enabled': True, 'mtu': 1500}}, 'openconfig-if-ip:ipv6': {'config': {'dhcp-client': False, 'enabled': False, 'mtu': 1500}, 'state': {'dhcp-client': False, 'enabled': False, 'mtu': 1500}}, 'state': {'enabled': True, 'index': 0}}]}}
+content is
+{'openconfig-interfaces:config': {'description': '222', 'enabled': True, 'arista-intf-augments:load-interval': 300,
+'loopback-mode': True, 'name': 'Loopback100', 'openconfig-vlan:tpid': 'openconfig-vlan-types:TPID_0X8100', 'type':
+'iana-if-type:softwareLoopback'}, 'openconfig-interfaces:hold-time': {'config': {'down': 0, 'up': 0}, 'state': {'down':
+0, 'up': 0}}, 'openconfig-interfaces:name': 'Loopback100', 'openconfig-interfaces:state': {'enabled': True,
+'loopback-mode': False, 'openconfig-vlan:tpid': 'openconfig-vlan-types:TPID_0X8100'},
+'openconfig-interfaces:subinterfaces': {'subinterface': [{'config': {'description': '222', 'enabled': True, 'index': 0},
+'index': 0, 'openconfig-if-ip:ipv4': {'config': {'dhcp-client': False, 'enabled': True, 'mtu': 1500}, 'state':
+{'dhcp-client': False, 'enabled': True, 'mtu': 1500}}, 'openconfig-if-ip:ipv6': {'config': {'dhcp-client': False,
+'enabled': False, 'mtu': 1500}, 'state': {'dhcp-client': False, 'enabled': False, 'mtu': 1500}}, 'state': {'enabled':
+True, 'index': 0}}]}}
 deleting int lo100
 status_code is 200
 ```

--- a/docs/telemetry/adapters/gnmireverse/index.md
+++ b/docs/telemetry/adapters/gnmireverse/index.md
@@ -7,16 +7,18 @@ categories:
 
 ## Introduction
 
-gNMIReverse is a Dial-Out gRPC service (available on our [Github](https://github.com/aristanetworks/goarista/tree/master/gnmireverse)
-page) that reverses the direction of the dial for gNMI Subscriptions.
-The gNMIReverse client (running along with gNMI target) on the switch sends data to the gNMIReverse Server.
+gNMIReverse is a Dial-Out gRPC service (available on our
+[Github](https://github.com/aristanetworks/goarista/tree/master/gnmireverse) page) that reverses the direction of the
+dial for gNMI Subscriptions.  The gNMIReverse client (running along with gNMI target) on the switch sends data to the
+gNMIReverse Server.
 
-This article contains steps on how to build the gNMIReverse client and server binaries 
-and examples on how to configure, the daemon to run the gNMIReverse client on EOS.
+This article contains steps on how to build the gNMIReverse client and server binaries and examples on how to configure,
+the daemon to run the gNMIReverse client on EOS.
 
 ## Prerequisite
 
-The following tools are required to proceed with this setup including cloning the repository and compiling client binary for EOS.
+The following tools are required to proceed with this setup including cloning the repository and compiling client binary
+for EOS.
 
 - [Go](https://golang.org/doc/install)
 - [Git](https://www.atlassian.com/git/tutorials/install-git)
@@ -90,8 +92,15 @@ Authorization Required:No
 
 gNMIReverse client daemon configuration (non-default VRF):
 
+Note: The `\` elements have been added to aid readability, these should be removed when entering the configuration.
+
 <pre><code>daemon gnmi_reverse_client_1
-   exec /mnt/flash/client -username cvpadmin -password arista <span style="color: red;">-target_addr=management/127.0.0.1:6030 -collector_addr=management/10.85.129.115:6000</span> -collector_tls=false -target_value=gb421 -sample /system/processes/process[pid=*]/state@15s
+   exec /mnt/flash/client -username cvpadmin -password arista         \
+   <span style="color: red;">  -target_addr=management/127.0.0.1:6030                           \
+     -collector_addr=management/10.85.129.115:6000</span>                    \
+     -collector_tls=false                                             \
+     -target_value=gb421                                              \
+     -sample /system/processes/process[pid=*]/state@15s
    no shutdown
 </code></pre>
 
@@ -119,8 +128,13 @@ Authorization Required:No
 
 gNMIReverse client daemon configuration (default VRF):
 
+Note: The `\` elements have been added to aid readability, these should be removed when entering the configuration.
+
 <pre><code>daemon gnmi_reverse_client_1
-   exec /mnt/flash/client -username cvpadmin -password arista <span style="color: red;">-target_addr=127.0.0.1:6030 -collector_addr=10.85.129.115:6000</span> -collector_tls=false -target_value=gb421 -sample /system/processes/process[pid=*]/state@15s
+   exec /mnt/flash/client -username cvpadmin -password arista \
+   <span style="color: red;">  -target_addr=127.0.0.1:6030                              \
+     -collector_addr=10.85.129.115:6000</span> -collector_tls=false  \
+     -target_value=gb421 -sample /system/processes/process[pid=*]/state@15s
    no shutdown
 </code></pre>
 
@@ -168,8 +182,16 @@ management api gnmi
 
 Configure the daemon to subscribe to the eos_native path as in following example:
 
+Note: The `\` elements have been added to aid readability, these should be removed when entering the configuration.
+
 <pre><code>daemon gnmi_reverse_client_1
-   exec /mnt/flash/client -username cvpadmin -password arista -target_addr=management/127.0.0.1:6030 -collector_addr=management/10.85.129.115:6000 -collector_tls=false -target_value=gb421 -sample /system/processes/process[pid=*]/state@30s <span style="color: red;">-origin eos_native -subscribe /Kernel/proc/meminfo/</span>
+   exec /mnt/flash/client -username cvpadmin -password arista \
+     -target_addr=management/127.0.0.1:6030                   \
+     -collector_addr=management/10.85.129.115:6000            \
+     -collector_tls=false -target_value=gb421                 \
+     -sample /system/processes/process[pid=*]/state@30s       \
+     <span style="color: red;">-origin eos_native                                       \
+     -subscribe /Kernel/proc/meminfo/</span>
    no shutdown
 </code></pre>
 
@@ -209,8 +231,17 @@ management api models
 
 Configure the gNMIReverse client daemon:
 
+Note: The `\` elements have been added to aid readability, these should be removed when entering the configuration.
+
 <pre><code>daemon gnmi_reverse_client_1
-   exec /mnt/flash/client -username cvpadmin -password arista -target_addr=management/127.0.0.1:6030 -collector_addr=management/10.85.129.115:6000 -collector_tls=false -target_value=gb421 -sample /system/processes/process[pid=*]/state@30s <span style="color: red;">-origin eos_native</span> -subscribe /Kernel/proc/meminfo/ <span style="color: red;">-subscribe /Smash/routing/status/</span>
+   exec /mnt/flash/client -username cvpadmin -password arista           \
+     -target_addr=management/127.0.0.1:6030                             \
+     -collector_addr=management/10.85.129.115:6000                      \
+     -collector_tls=false -target_value=gb421                           \
+     -sample /system/processes/process[pid=*]/state@30s                 \
+     <span style="color: red;">-origin eos_native</span>                                                 \
+     -subscribe /Kernel/proc/meminfo/                                   \
+     <span style="color: red;">-subscribe /Smash/routing/status/</span>
    no shutdown
 </code></pre>
 


### PR DESCRIPTION
- updates the markdownlint rules to flex on a few items. notably the following:
  - inline-html elements which are used for MkDocs stuff
  - line length for tables
- resolves a grip of linting issues inclusive of the relaxed linting rules for various elements.   

  a couple of comments here: 
  - in some cases, there were very large (unreadable anyway) code blocks that were exceeding the line-length rules.  i wrapped with wild abandon.
  - in other cases, there were long CLI examples that I reformatted to use `\` continuation indicators as appropriate.  in some cases this may not have been appropriate in which case, I added text explaining to the reader that the continuation marks were there for readability and they will need to modify this prior to using these in their configs.  which seemed fine given that these were for involved command-line flags which need to be edited anyway.