### PR TITLE
config persistence text

### DIFF
--- a/docs/configuration/openconfig.md
+++ b/docs/configuration/openconfig.md
@@ -238,12 +238,12 @@ Listen addresses: ::
 ## Configuration Persistence
 
 By default, within EOS, the application of gNMI `Set` RPCs are not persisted to the `startup-config`.  A `copy
-running-config startup-config` execution would be required in order to save configuration updates imposed via gNMI.
+running-config startup-config` execution is required in order to save configuration updates imposed via gNMI.
 
-If the operator desire to be able to save gNMI-based configuration, persistence can be enabled by adding the following
-configuration. With this option, all gnmi `Set` operations will be saved to the `startup-config`.  Note, the
-configuration is saved using Arista's EOS configuration syntax and there is no corresponding presentation of the
-OpenConfig syntax.
+As of EOS 4.28.0F, if the operator desire to be able to save gNMI-based configuration automatically, persistence can be
+enabled by adding the following configuration. With this option, all gnmi `Set` operations will be saved to the
+`startup-config`. Note, the configuration is saved using Arista's EOS configuration syntax and there is no corresponding
+presentation of the OpenConfig syntax.
 
 ```text
 management api gnmi

--- a/docs/configuration/openconfig.md
+++ b/docs/configuration/openconfig.md
@@ -228,7 +228,54 @@ QoS DSCP: none
 Authorization required: no
 Accounting requests: no
 Certificate username authentication: no
-Notification timestamp: send time
+Notification timestamp: send time  !! note timetamp mode.
+Listen addresses: ::
+```
+
+</p>
+</details>
+
+## Configuration Persistence
+
+By default, within EOS, the application of gNMI `Set` RPCs are not persisted to the `startup-config`.  A `copy
+running-config startup-config` execution would be required in order to save configuration updates imposed via gNMI.
+
+If the operator desire to be able to save gNMI-based configuration, persistence can be enabled by adding the following
+configuration. With this option, all gnmi `Set` operations will be saved to the `startup-config`.  Note, the
+configuration is saved using Arista's EOS configuration syntax and there is no corresponding presentation of the
+OpenConfig syntax.
+
+```text
+management api gnmi
+   transport grpc <NAME>
+   operation set persistence
+```
+
+If there is a need to retrun to the default mode of gNMI configuration non-persistence, this can be disabled using the
+following commands.
+
+```text
+no operation set persistence
+default operation set persistence
+```
+
+<details><summary>Validation</summary>
+<p>
+
+```text
+#show management api gnmi
+Octa: enabled
+Set persistence: enabled  !! confirmation
+
+Transport: default
+Enabled: yes
+Server: running on port 6030, in default VRF
+SSL profile: none
+QoS DSCP: none
+Authorization required: no
+Accounting requests: no
+Certificate username authentication: no
+Notification timestamp: last change time
 Listen addresses: ::
 ```
 

--- a/docs/configuration/openconfig.md
+++ b/docs/configuration/openconfig.md
@@ -238,9 +238,9 @@ Listen addresses: ::
 ## Configuration Persistence
 
 By default, within EOS, the application of gNMI `Set` RPCs are not persisted to the `startup-config`.  A `copy
-running-config startup-config` execution is required in order to save configuration updates imposed via gNMI.
+running-config startup-config` is required in order to save configuration updates imposed via gNMI.
 
-As of EOS 4.28.0F, if the operator desire to be able to save gNMI-based configuration automatically, persistence can be
+As of EOS 4.28.0F, if the operator desires to be able to save gNMI-driven configuration automatically, persistence can be
 enabled by adding the following configuration. With this option, all gnmi `Set` operations will be saved to the
 `startup-config`. Note, the configuration is saved using Arista's EOS configuration syntax and there is no corresponding
 presentation of the OpenConfig syntax.
@@ -251,7 +251,7 @@ management api gnmi
    operation set persistence
 ```
 
-If there is a need to retrun to the default mode of gNMI configuration non-persistence, this can be disabled using the
+If there is a need to return to the default mode of gNMI configuration non-persistence, this can be disabled using the
 following commands.
 
 ```text

--- a/docs/configuration/openconfig.md
+++ b/docs/configuration/openconfig.md
@@ -228,7 +228,7 @@ QoS DSCP: none
 Authorization required: no
 Accounting requests: no
 Certificate username authentication: no
-Notification timestamp: send time  !! note timetamp mode.
+Notification timestamp: send time  !! note: timestamp mode
 Listen addresses: ::
 ```
 
@@ -265,7 +265,7 @@ default operation set persistence
 ```text
 #show management api gnmi
 Octa: enabled
-Set persistence: enabled  !! confirmation
+Set persistence: enabled  !! note: persistence state
 
 Transport: default
 Enabled: yes


### PR DESCRIPTION
adds notes re: enabling configuration persistence for gNMI `Set` RPCs.