### PR TITLE
Update pygnmi examples

### DIFF
--- a/src/pygnmi/capabilities.py
+++ b/src/pygnmi/capabilities.py
@@ -1,11 +1,18 @@
-from pygnmi.client import gNMIclient
-from pprint import pprint as pp
+import os
 import json
+from pprint import pprint as pp
 
-host = ("198.51.100.105", "6030")
-username = "arista"
-password = "arista"
+from pygnmi.client import gNMIclient
 
-with gNMIclient(target=host, username=username, password=password, insecure=True) as gc:
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "arista")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "arista")
+
+host = (ARISTA_HOST, ARISTA_PORT)
+
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     result = gc.capabilities()
     pp(result)

--- a/src/pygnmi/delete.py
+++ b/src/pygnmi/delete.py
@@ -1,13 +1,21 @@
-from pygnmi.client import gNMIclient
+import os
+import json
 from pprint import pprint as pp
 
-host = ("198.51.100.105", "6030")
-username = "arista"
-password = "arista"
+from pygnmi.client import gNMIclient
+
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "arista")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "arista")
+
+host = (ARISTA_HOST, ARISTA_PORT)
 
 d = [
     "openconfig-interfaces:interfaces/interface[name=Ethernet1]/config/description",
 ]
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     result = gc.set(delete=d)
     print(result)

--- a/src/pygnmi/get.py
+++ b/src/pygnmi/get.py
@@ -1,13 +1,22 @@
-from pygnmi.client import gNMIclient, telemetryParser
+import os
 import json
 
-host = ("198.51.100.105", "6030")
+from pygnmi.client import gNMIclient, telemetryParser
+
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "arista")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "arista")
+
+host = (ARISTA_HOST, ARISTA_PORT)
 
 paths = [
     "interfaces/interface[name=Ethernet1]/state/counters",
     "network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state",
 ]
 
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     raw_data = gc.get(path=paths, encoding="json_ietf")
     print(json.dumps(raw_data, sort_keys=True, indent=2))

--- a/src/pygnmi/gnmi_example.py
+++ b/src/pygnmi/gnmi_example.py
@@ -1,14 +1,20 @@
 # Modules
-from pygnmi.client import gNMIclient
+import os
 import json
 
-# Variables
-host = ("198.51.100.67", "6030")
+from pygnmi.client import gNMIclient
+
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "ansible")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "ansible")
+
+host = (ARISTA_HOST, ARISTA_PORT)
 
 # Body
 if __name__ == "__main__":
     with gNMIclient(
-        target=host, username="ansible", password="ansible", insecure=True
+        target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
     ) as gc:
         result = gc.get(path=["openconfig:interfaces"])
     print(json.dumps(result, indent=4))

--- a/src/pygnmi/sub.py
+++ b/src/pygnmi/sub.py
@@ -1,4 +1,13 @@
+import os
+
 from pygnmi.client import gNMIclient, telemetryParser
+
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "arista")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "arista")
+
+host = (ARISTA_HOST, ARISTA_PORT)
 
 subscribe = {
     "subscription": [
@@ -17,9 +26,9 @@ subscribe = {
     "encoding": "json",
 }
 
-host = ("198.51.100.105", "6030")
-
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     telemetry_stream = gc.subscribe(subscribe=subscribe)
     for telemetry_entry in telemetry_stream:
         print(telemetryParser(telemetry_entry))

--- a/src/pygnmi/update.py
+++ b/src/pygnmi/update.py
@@ -1,16 +1,23 @@
-from pygnmi.client import gNMIclient
-from pprint import pprint as pp
+import os
 import json
+from pprint import pprint as pp
 
-host = ("198.51.100.105", "6030")
-username = "arista"
-password = "arista"
+from pygnmi.client import gNMIclient
+
+ARISTA_HOST = os.getenv("ARISTA_HOST", "198.51.100.105")
+ARISTA_PORT = os.getenv("ARISTA_PORT", "6030")
+ARISTA_USERNAME = os.getenv("ARISTA_USERNAME", "arista")
+ARISTA_PASSWORD = os.getenv("ARISTA_PASSWORD", "arista")
+
+host = (ARISTA_HOST, ARISTA_PORT)
 
 print("GET RPC, interface Ethernet1 config, before the update")
 
-paths = ["openconfig-interfaces:interfaces/interface[name=Ethernet1]/config"]
+paths = ["openconfig:/interfaces/interface[name=Ethernet1]/config"]
 
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     raw_data = gc.get(path=paths, encoding="json_ietf")
     print(json.dumps(raw_data, sort_keys=True, indent=2))
 
@@ -18,19 +25,23 @@ print("\nSET RPC, update, interface Ethernet1")
 
 u = [
     (
-        "openconfig-interfaces:interfaces/interface[name=Ethernet1]",
+        "openconfig:/interfaces/interface[name=Ethernet1]",
         {"config": {"name": "Ethernet1", "enabled": True, "description": "Test"}},
     )
 ]
 
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_USERNAME, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     result = gc.set(update=u)
     print(result)
 
 print("\nGET RPC, interface Ethernet1 config, after the update")
 
-paths = ["openconfig-interfaces:interfaces/interface[name=Ethernet1]/config"]
+paths = ["openconfig:/interfaces/interface[name=Ethernet1]/config"]
 
-with gNMIclient(target=host, username="arista", password="arista", insecure=True) as gc:
+with gNMIclient(
+    target=host, username=ARISTA_PASSWORD, password=ARISTA_PASSWORD, insecure=True
+) as gc:
     raw_data = gc.get(path=paths, encoding="json_ietf")
     print(json.dumps(raw_data, sort_keys=True, indent=2))


### PR DESCRIPTION
My primary goal was to update the origin path in `update.py` file because I was getting the following error
```
"update requests with an origin of "openconfig-interfaces" are not supported"
```
Here is the main change I made to this script
```python
# was
paths = ["openconfig-interfaces:interfaces/interface[name=Ethernet1]/config"]
# Replaced with
paths = ["openconfig:/interfaces/interface[name=Ethernet1]/config"]
```

Since I was working on it, I also took the opportunity to add support for environment variables for all scripts and I formatted them with black.
I was able to test all scripts successfully with the latest version of pygnmi and a ceos device running `4.27.3F`


