### PR TITLE
Add "no shutdown" to gnmi transport

### DIFF
--- a/docs/examples/gnmi-clients/gnmic/index.md
+++ b/docs/examples/gnmi-clients/gnmic/index.md
@@ -44,6 +44,7 @@ version : 0.17.0
 
 management api gnmi
    transport grpc default
+       no shutdown
    provider eos-native
 
 ceos3#                show management api gnmi


### PR DESCRIPTION
I needed to add the `no shutdown` to activate gnmi