### PR TITLE
Pin Mkdocs version and fix/enable features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==9.0.9
       - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_description: Arista Open Management repository documentation
 # Repository information
 repo_name: openmgmt on Github
 repo_url: https://github.com/aristanetworks/openmgmt
+edit_uri: edit/main/docs
 # Configuration
 theme:
   name: material
@@ -21,6 +22,9 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
   favicon: _media/favicon.ico
+  features:
+    - content.action.edit
+    - content.code.copy
 extra:
   analytics:
     provider: google
@@ -31,10 +35,14 @@ extra:
     - icon: fontawesome/solid/globe
       link: https://www.arista.com
 markdown_extensions:
-  - pymdownx.snippets
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
+  - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
 
 extra_css:
   - stylesheets/extra.material.css


### PR DESCRIPTION
- Pin Mkdocs version to `9.0.9` (latest)
- Copy button must be set in config file for it to be present (new in version 9.x and currently broken)
- Enabled features for future enhancement of examples, output (short form)
- Enabled feature for content tab use (grouping items with same scope in tabs
- Enabled edit button for quicker contributions